### PR TITLE
Исправить проверку длины описания позиции для UTF-8 строк

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,9 @@
             "email": "patyrsa@com.gmail"
         }
     ],
-    "require": {},
+    "require": {
+        "ext-mbstring": "*"
+    },
     "autoload": {
         "psr-4": { "orangedata\\": "" }
     }

--- a/orangedata_client.php
+++ b/orangedata_client.php
@@ -12,7 +12,8 @@ use \DateTime;
 use \Exception;
 
 class orangedata_client {
-
+    
+    const MAX_ORDER_ID_LENGTH = 64;
     private $order_request;
     private $correction_request;
     private $api_url;
@@ -47,7 +48,7 @@ class orangedata_client {
 
     /**
      * create_order(a, b, c, d, e*, f*) - Создание чека
-     *  @param string $id (a) - Идентификатор документа (Строка от 1 до 32 символов)
+     *  @param string $id (a) - Идентификатор документа (Строка от 1 до 64 символов)
      *  @param int $type (b) - Признак расчета (Число от 1 до 4):
      *      1 - Приход
      *      2 - Возврат прихода
@@ -317,7 +318,7 @@ class orangedata_client {
      *  @throws Exception
      */
     public function get_order_status($id) {
-        if (strlen($id) > 32 OR strlen($id) == 0) {
+        if (strlen($id) > self::MAX_ORDER_ID_LENGTH OR strlen($id) == 0) {
             throw new Exception('Invalid order identifier');
         }
         $curl = is_int($this->api_url) ? $this->prepare_curl($this->edit_url($this->api_url, TRUE) . $this->inn . '/status/' . $id) : $this->prepare_curl($this->api_url . '/api/v2/documents/' . $this->inn . '/status/' . $id);
@@ -533,7 +534,7 @@ class orangedata_client {
      *  @throws Exception
      */
     public function get_correction_status($id) {
-        if (strlen($id) > 32 OR strlen($id) == 0) {
+        if (strlen($id) > self::MAX_ORDER_ID_LENGTH OR strlen($id) == 0) {
             throw new Exception('Invalid order identifier');
         }
         $curl = is_numeric($this->api_url) ? $this->prepare_curl($this->edit_url($this->api_url,FALSE) . $this->inn . '/status/' . $id) : $this->prepare_curl($this->api_url . '/api/v2/corrections/' . $this->inn . '/status/' . $id);

--- a/orangedata_client.php
+++ b/orangedata_client.php
@@ -132,7 +132,7 @@ class orangedata_client {
      *  @throws Exception
      */
     public function add_position_to_order($quantity, $price, $tax, $text, $paymentMethodType = null, $paymentSubjectType = null) {
-        if (is_numeric($quantity) and is_numeric($price) and preg_match('/^[123456]{1}$/', $tax) and strlen($text) < 129) {
+        if (is_numeric($quantity) and is_numeric($price) and preg_match('/^[123456]{1}$/', $tax) and mb_strlen($text) < 129) {
             $position = new \stdClass();
             $position->quantity = (float) $quantity;
             $position->price = (float) $price;


### PR DESCRIPTION
Сейчас, если попытаться добавить позицию с описанием на русском языке, библиотека может выбросить исключение "Invalid Position Quantity, Price, Tax or Text" из-за того, как `strlen` в php работает с многобайтными кодировками.

При этом, бэкэнд Orange Data без проблем примет такую строку. 

[Пример](https://mothereff.in/byte-counter#%D1%80%D1%8B%D0%B2%D0%BF%D0%B0%D0%BE%D1%80%D1%8B%D0%B2%D0%BF%D0%BE%D1%80%D0%B0%D0%BF%20%D1%8B%D1%80%D0%B2%D0%BF%D0%B0%D0%BE%D1%8B%D0%B2%D1%80%D0%BF%D0%B0%20%D1%8B%D0%BE%D0%B2%D1%80%D0%BF%D0%B0%D1%8B%D0%B2%D0%BE%D1%80%D0%BF%D0%B0%D0%BE%20%D0%BF%D0%B0%D1%8B%D0%B2%D1%80%D0%BF%D0%B0%D0%BE%D1%8B%D0%B2%D0%BF%D0%B0%20%D0%BF%D1%8B%D0%B2%D0%BE%D1%80%D0%B0%D0%BF%D1%80%D1%8B%D0%B2%D0%BF%D0%B0%20%D1%8B%D1%80%D0%B0%D0%BF): строка "рывпаорывпорап ырвпаоыврпа ыоврпаыворпао паыврпаоывпа пыворапрывпа ырап" содержит всего 71 символ, без проблем обрабатывается бэкэндом, но не пропускается этой библиотекой.