### PR TITLE
Корректные значения полей group и paymentOperatorINN в файле примера

### DIFF
--- a/examples/order.php
+++ b/examples/order.php
@@ -24,7 +24,7 @@ try {
     'customerContact' => 'example@example.com',
     'taxationSystem' => 1,
     'key' => '1234567',
-    'group' => 'Main',
+    'group' => null,
   ];
 
   $position = [


### PR DESCRIPTION
Два небольших исправления в файле examples/order.php. Без них пример кода не работает, выдает следующие ошибки:

`PHP Warning:  Undefined array key "group" in /home/.../orangedata_client.php on line 81`

`PHP Warning:  Undefined array key "paymentOperatorINN" in /home/.../orangedata_client.php on line 175`