### PR TITLE
Allow setting port number as string value

### DIFF
--- a/orangedata_client.php
+++ b/orangedata_client.php
@@ -419,7 +419,7 @@ class orangedata_client {
     if (strlen($id) > 32 OR strlen($id) == 0) {
       throw new Exception('Invalid order identifier');
     }
-    $curl = is_int($this->api_url) ? $this->prepare_curl($this->edit_url($this->api_url, TRUE) . $this->inn . '/status/' . $id) : $this->prepare_curl($this->api_url . '/api/v2/documents/' . $this->inn . '/status/' . $id);
+    $curl = is_numeric($this->api_url) ? $this->prepare_curl($this->edit_url($this->api_url, TRUE) . $this->inn . '/status/' . $id) : $this->prepare_curl($this->api_url . '/api/v2/documents/' . $this->inn . '/status/' . $id);
     curl_setopt($curl, CURLOPT_POST, false);
     $answer = curl_exec($curl);
     $info = curl_getinfo($curl);


### PR DESCRIPTION
Исправлена маленькая ошибка в функции get_order_status().

Если адрес подключения был задан в виде строки, содержащей номер порта, эта строка интерпретировалась как URL и запрос делался на адрес 0.0.9.139.

```
$client = [
  'api_url' => '2443',
  ...
```

В файле examples/order.php порт задан именно строкой, поэтому проверка состояния чека не срабатывала.

В функции send_order() этой ошибки нет.